### PR TITLE
[Easy][Fix] User info displayed in modal

### DIFF
--- a/app/css/user-panel.scss
+++ b/app/css/user-panel.scss
@@ -1,7 +1,7 @@
 .user-panel {
   display: flex;
   flex-flow: column nowrap;
-  padding: 16px;
+  padding: 24px;
 
   > .header {
     flex: 0 0 48px;


### PR DESCRIPTION
# Description

There is an issue with the display of user information inside the modal window.
![image](https://github.com/AdyCastEX/frontend_test/assets/6531109/856fbf23-4557-4425-a08c-c3e264d3812d)
Some of the information is not properly aligned with where it should be. Find out what's causing this issue and fix it. Expected result should look like this:
![image](https://github.com/AdyCastEX/frontend_test/assets/6531109/7d6b73c6-5b55-4d28-a30c-c7f39cb10f12)


# Instructions

1. Checkout to `fix/modal-info-display` in your forked copy
2. Create a new branch from `fix/modal-info-display` (e.g. `fix/modal-info-display-solution`)
3. Make the necessary changes and commits
4. Create a Pull Request directed to your forked copy of `fix/modal-info-display`. Improperly targeted PRs will be closed
    - ❌ into `AdyCastEX:fix/modal-info-display` from `somefork:fix/modal-info-display`
    - ❌ into `AdyCastEX:main` from `somefork:fix/modal-info-display`
    - ✅ into `fix/modal-info-display` from `fix/modal-info-display-solution`
5. Provide screenshots or videos of the fixed modal info display