### PR TITLE
Fix className typos on gallery

### DIFF
--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -93,13 +93,13 @@ const Gallery = ({ users }: GalleryProps) => {
                   </div>
                   <div className="field">
                     <FaLocationDot className="icon" />
-                    <div className="data">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
+                    <div className="value">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
                   </div>
                   <div className="field">
                     <FaPhone className="icon" />
                     <div className="value">{selectedUser.phone}</div>
                   </div>
-                  <div className="fields">
+                  <div className="field">
                     <FaEnvelope className="icon" />
                     <div className="value">{selectedUser.email}</div>
                   </div>


### PR DESCRIPTION
The alignment of the list item details are not aligned due to some className typos and different className used.

**RESULTS**

https://github.com/AdyCastEX/frontend_test/assets/35484571/d7b219b4-e24b-4045-961e-9af440c8ae0f

