### PR TITLE
Fix/modal info display solution

### DIFF
--- a/app/css/user-panel.scss
+++ b/app/css/user-panel.scss
@@ -1,7 +1,7 @@
 .user-panel {
   display: flex;
   flex-flow: column nowrap;
-  padding: 16px;
+  padding: 24px;
 
   > .header {
     flex: 0 0 48px;

--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -99,7 +99,7 @@ const Gallery = ({ users }: GalleryProps) => {
                     <FaPhone className="icon" />
                     <div className="value">{selectedUser.phone}</div>
                   </div>
-                  <div className="fields">
+                  <div className="field">
                     <FaEnvelope className="icon" />
                     <div className="value">{selectedUser.email}</div>
                   </div>

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^29.6.1",
     "sass": "^1.64.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Added  Minor padding for  

1.   .user-panel

```
  padding: 24px;

```

2.  Found Error from value typo of fields instead of field causing display error for the email display


Buggy code (gallery.tsx)
```
 <div className="fields">
                    <FaEnvelope className="icon" />
                    <div className="value">{selectedUser.email}</div>
                  </div>
```

Fixed (gallery.tsx)
```


 <div className="field">
                    <FaEnvelope className="icon" />
                    <div className="value">{selectedUser.email}</div>
                  </div>
```
Screenshot:
![User info displayed in modal fixed](https://github.com/user-attachments/assets/76f25d37-263c-4303-95d4-e61b90df186a)

